### PR TITLE
Switch along with Mojave's Dark Mode

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -28,4 +28,11 @@ export default {
     type: 'integer',
     default: '10',
   },
+
+  followMacSystemTheme: {
+    order: 6,
+    description: 'Determine if themes should be automatically changed when the macOS system theme changes',
+    type: 'boolean',
+    default: true,
+  },
 };

--- a/lib/dark-mode.js
+++ b/lib/dark-mode.js
@@ -3,6 +3,7 @@
 import Config from './config';
 import { CompositeDisposable } from 'atom';
 import AmbientLight from './ambient-light';
+import MacAutoSwitch from './mac-auto-switch';
 
 let notificationsOptions = { icon: 'light-bulb' };
 
@@ -30,18 +31,25 @@ export default {
     return atom.config.get('dark-mode.ambientLightThreshold');
   },
 
+  get followMacTheme() {
+    return atom.config.get('dark-mode.followMacSystemTheme');
+  },
+
   activate() {
     this.subscriptions = new CompositeDisposable();
     this.registerCommands();
     this.registerCallbacks();
     this.ambientLight = new AmbientLight(this.threshold, this.onLight.bind(this), this.onDark.bind(this));
     this.ambientLight.active = this.state;
+    this.macAutoSwitch = new MacAutoSwitch(this.onLight.bind(this), this.onDark.bind(this));
+    this.macAutoSwitch.active = this.followMacTheme;
 
     this._startupNotification();
   },
 
   deactivate() {
     this.ambientLight.active = false;
+    this.macAutoSwitch.active = false;
     this.subscriptions.dispose();
   },
 
@@ -61,6 +69,10 @@ export default {
 
     this.subscriptions.add(atom.config.onDidChange('dark-mode.ambientLightThreshold', ({newValue}) => {
       this.ambientLight.threshold = newValue;
+    }));
+
+    this.subscriptions.add(atom.config.onDidChange('dark-mode.followMacSystemTheme', ({newValue}) => {
+      this.macAutoSwitch.active = newValue;
     }));
   },
 

--- a/lib/mac-auto-switch.js
+++ b/lib/mac-auto-switch.js
@@ -1,0 +1,35 @@
+'use babel';
+
+const { systemPreferences } = require('electron');
+
+export default class {
+  constructor(onLight = () => {}, onDark = () => {}) {
+    this.onLight = onLight;
+    this.onDark = onDark;
+  }
+
+  get active() {
+    return this._active || false;
+  }
+
+  set active(state) {
+    state ? this._activate() : this._deactivate();
+    this._active = state;
+  }
+
+  _activate() {
+    if (!systemPreferences) { return; }
+    this._sub = systemPreferences.subscribeNotification('AppleInterfaceThemeChangedNotification', () => {
+      if (systemPreferences.isDarkMode()) {
+        this.onDark();
+      } else {
+        this.onLight();
+      }
+    })
+  }
+
+  _deactivate() {
+    if (!systemPreferences) { return; }
+    systemPreferences.unsubscribeNotification(this._sub);
+  }
+}


### PR DESCRIPTION
Don't merge this until Electron 3 lands in Atom, but this should address #5. Dark Mode should switch along with the system Dark Mode.