### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 /spec export-ignore
 /.eslintrc.js export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+/spec export-ignore
+/.eslintrc.js export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/*.gif export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).

This PR will exclude the `.gif` files which will save about 13MB on each download.

Happy Hacktoberfest!